### PR TITLE
Add CORS specification

### DIFF
--- a/plumber.R
+++ b/plumber.R
@@ -15,3 +15,9 @@ function(query) {
     response = list(results = purrr::transpose(matches))
   )
 }
+
+#* @filter cors
+cors <- function(res) {
+  res$setHeader("Access-Control-Allow-Origin", "*")
+  plumber::forward()
+}


### PR DESCRIPTION
This is required to allow for cross-origin requests (for example, front-end running on `localhost:3000`).
